### PR TITLE
Enabled the possibility to provide a logger and handler to @begin.logging decorator.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,12 @@ python:
   - 3.2
   - 3.3
   - 3.4
+  - 3.5
   - pypy
 install:
   - pip install -r requirements.txt
+  # coverage 4 dropped support for 3.2 so we need to downgrade
+  - if [[ $TRAVIS_PYTHON_VERSION == '3.2' ]]; then pip install 'coverage<4'; fi
   - python setup.py install
 script:
   - coverage run setup.py test

--- a/begin/__init__.py
+++ b/begin/__init__.py
@@ -7,7 +7,7 @@ from begin.subcommands import subcommand
 from begin.version import __version__
 
 from begin.extensions import tracebacks
-from begin.extensions import logger_old as logging
+from begin.extensions import logger_func as logging
 from begin.extensions import logger
 
 import begin.formatters

--- a/begin/__init__.py
+++ b/begin/__init__.py
@@ -7,7 +7,8 @@ from begin.subcommands import subcommand
 from begin.version import __version__
 
 from begin.extensions import tracebacks
-from begin.extensions import logger as logging
+from begin.extensions import logger_old as logging
+from begin.extensions import logger
 
 import begin.formatters
 import begin.utils

--- a/begin/extensions.py
+++ b/begin/extensions.py
@@ -129,6 +129,10 @@ class Logging(Extension):
         handler.setFormatter(formatter)
 
 
+def logger_old(func):
+    "Add command line extension for logging module"
+    return Logging(func)
+
 def logger(**kwargs):
     "Add command line extension for logging module"
     def decorator(func):

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -350,7 +350,7 @@ def test_keyword_only(self):
         self.opts.tracebacks = True
         self.opts.tbdir = None
         cmdline.apply_options(main, self.opts)
-        enable.assert_called_one(format='txt', logdir=None)
+        enable.assert_called_once_with(format='txt', logdir=None)
 
     def test_subcommand(self):
         @subcommands.subcommand


### PR DESCRIPTION
You can provide now an instance of logger and/or handler with @begin.logger decorator. The old way just works fine. 

PD: I've just added the unittest modifications shown by @samjacobson in [this Pull request](https://github.com/aliles/begins/pull/61)