### PR TITLE
Two small changes from ropez and esc

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -298,6 +298,6 @@ be made using GitHub's `issues system`_.
    :target: https://coveralls.io/r/aliles/begins?branch=master
    :alt: Latest PyPI version
 
-.. |pypi_version| image:: https://pypip.in/v/begins/badge.png
-   :target: https://crate.io/packages/begins/
+.. |pypi_version| image:: https://img.shields.io/pypi/v/bloscpack.svg
+   :target: https://pypi.python.org/pypi/begins
    :alt: Latest PyPI version

--- a/begin/extensions.py
+++ b/begin/extensions.py
@@ -113,7 +113,7 @@ class Logging(Extension):
         # formatter
         fmt = opts.logfmt
         if fmt is None:
-            if opts.logfile is None:
+            if sys.stdout.isatty() and opts.logfile is None:
                 fmt = '%(message)s'
             else:
                 fmt = '[%(asctime)s] [%(levelname)s] [%(pathname)s:%(lineno)s] %(message)s'


### PR DESCRIPTION
Fix URLs in the README, and default to using logfile format on stdout when stdout is not a TTY.