### PR TITLE
Add 'double_flags' option -- from Lapin0t

### DIFF
--- a/begin/cmdline.py
+++ b/begin/cmdline.py
@@ -101,7 +101,7 @@ def populate_flag(parser, param, defaults, double_flags):
     if double_flags:
         parser.add_argument(('--' if default else '--no-') + param_name,
                 action='store_true' if default else 'store_false',
-                default=default, dest=param.name, help=help)
+                default=default, dest=param.name, help='')
 
 
 def populate_option(parser, param, defaults, short_args):

--- a/begin/cmdline.py
+++ b/begin/cmdline.py
@@ -85,7 +85,7 @@ def program_name(filename, func):
     return func.__name__
 
 
-def populate_flag(parser, param, defaults):
+def populate_flag(parser, param, defaults, double_flags):
     """Add a flag option to the parser"""
     default = defaults.from_param(param)
     if not isinstance(default, bool):
@@ -93,16 +93,19 @@ def populate_flag(parser, param, defaults):
     help = ''
     if param.annotation is not param.empty:
         help = param.annotation + ' '
-    parser.add_argument('--' + param.name.replace('_', '-'),
-            action='store_true', default=default, dest=param.name,
-            help=(help + '(default: %(default)s)'if not default else ''))
-    parser.add_argument('--no-' + param.name.replace('_', '-'),
-            action='store_false', default=default, dest=param.name,
-            help=(help + '(default: %(default)s)' if default else ''))
+    param_name = param.name.replace('_', '-')
+    parser.add_argument(('--no-' if default else '--') + param_name,
+            action='store_false' if default else 'store_true',
+            default=default, dest=param.name,
+            help=(help + '(default: %(default)s)'))
+    if double_flags:
+        parser.add_argument(('--' if default else '--no-') + param_name,
+                action='store_true' if default else 'store_false',
+                default=default, dest=param.name, help=help)
 
 
 def populate_option(parser, param, defaults, short_args):
-    """Add a regulre option to the parser"""
+    """Add a regular option to the parser"""
     kwargs = {'default': defaults.from_param(param)}
     kwargs['metavar'] = defaults.metavar(param.name)
     if param.annotation is not param.empty:
@@ -121,7 +124,8 @@ def populate_option(parser, param, defaults, short_args):
     parser.add_argument(*args, **kwargs)
 
 
-def populate_parser(parser, defaults, funcsig, short_args, lexical_order):
+def populate_parser(parser, defaults, funcsig, short_args, lexical_order,
+                    double_flags):
     """Populate parser according to function signature
 
     Use the parameters accepted by the source function, according to the
@@ -136,7 +140,7 @@ def populate_parser(parser, defaults, funcsig, short_args, lexical_order):
                 param.kind == param.KEYWORD_ONLY or \
                 param.kind == param.POSITIONAL_ONLY:
             if isinstance(param.default, bool):
-                populate_flag(parser, param, defaults)
+                populate_flag(parser, param, defaults, double_flags)
             else:
                 populate_option(parser, param, defaults, short_args)
         elif param.kind == param.VAR_POSITIONAL:
@@ -151,8 +155,8 @@ def populate_parser(parser, defaults, funcsig, short_args, lexical_order):
 
 
 def create_parser(func, env_prefix=None, config_file=None, config_section=None,
-        short_args=True, lexical_order=False, sub_group=None, plugins=None,
-        collector=None, formatter_class=argparse.HelpFormatter):
+        short_args=True, lexical_order=False, double_flags=True, sub_group=None,
+        plugins=None, collector=None, formatter_class=argparse.HelpFormatter):
     """Create and OptionParser object from a function definition.
 
     Use the function's signature to generate an OptionParser object. Default
@@ -178,7 +182,7 @@ def create_parser(func, env_prefix=None, config_file=None, config_section=None,
             have_extensions = True
         func = getattr(func, '__wrapped__')
     funcsig = signature(func)
-    populate_parser(parser, defaults, funcsig, short_args, lexical_order)
+    populate_parser(parser, defaults, funcsig, short_args, lexical_order, double_flags)
     # Subcommands
     collector = collector if collector is not None else subcommands.COLLECTORS[sub_group]
     if plugins is not None:
@@ -196,7 +200,8 @@ def create_parser(func, env_prefix=None, config_file=None, config_section=None,
                     conflict_handler='resolve', description=subfunc.__doc__,
                     formatter_class=formatter_class)
             defaults.set_config_section(subfunc.__name__)
-            populate_parser(subparser, defaults, funcsig, short_args, lexical_order)
+            populate_parser(subparser, defaults, funcsig, short_args,
+                            lexical_order, double_flags)
     have_extensions = False
     return parser
 

--- a/begin/main.py
+++ b/begin/main.py
@@ -58,22 +58,8 @@ class Program(Wrapping):
 
 
 def start(func=None, **kwargs):
-    """Return True if called in a module that is executed.
-
-    Inspects the '__name__' in the stack frame of the caller, comparing it
-    to '__main__'. Thus allowing the Python idiom:
-
-    >>> if __name__ == '__main__':
-    ...     pass
-
-    To be replace with:
-
-    >>> import begin
-    >>> if begin.start():
-    ...    pass
-
-    Can also be used as a decorator to register a function to run after the
-    module has been loaded.
+    """Decorator to register a function to run after the module has been
+    loaded.
 
     >>> @begin.start
     ... def main():
@@ -108,27 +94,19 @@ def start(func=None, **kwargs):
 
     The environment variable 'PY_FIRST' will be used instead of 'FIRST'.
     """
+
     def _start(func):
-        prog = Program(func, **kwargs)
         if func.__module__ == '__main__':
+            prog = Program(func, **kwargs)
             try:
-                prog.start()
+                sys.exit(prog.start())
             except KeyboardInterrupt:
                 sys.exit(1)
-        return prog
+        return func
 
     # start() is a decorator factory
     if func is None and len(kwargs) > 0:
         return _start
-    # start() is a boolean function
-    elif func is None:
-        stack = inspect.stack()
-        if len(stack) < 1:
-            return False
-        frame = stack[1][0]
-        if not inspect.isframe(frame):
-            return False
-        return frame.f_globals['__name__'] == '__main__'
     # not correctly used to decorate a function
     elif not callable(func):
         raise ValueError("Function '{0!r}' is not callable".format(func))

--- a/begin/main.py
+++ b/begin/main.py
@@ -58,8 +58,22 @@ class Program(Wrapping):
 
 
 def start(func=None, **kwargs):
-    """Decorator to register a function to run after the module has been
-    loaded.
+    """Return True if called in a module that is executed.
+
+    Inspects the '__name__' in the stack frame of the caller, comparing it
+    to '__main__'. Thus allowing the Python idiom:
+
+    >>> if __name__ == '__main__':
+    ...     pass
+
+    To be replace with:
+
+    >>> import begin
+    >>> if begin.start():
+    ...    pass
+
+    Can also be used as a decorator to register a function to run after the
+    module has been loaded.
 
     >>> @begin.start
     ... def main():
@@ -94,19 +108,27 @@ def start(func=None, **kwargs):
 
     The environment variable 'PY_FIRST' will be used instead of 'FIRST'.
     """
-
     def _start(func):
+        prog = Program(func, **kwargs)
         if func.__module__ == '__main__':
-            prog = Program(func, **kwargs)
             try:
-                sys.exit(prog.start())
+                prog.start()
             except KeyboardInterrupt:
                 sys.exit(1)
-        return func
+        return prog
 
     # start() is a decorator factory
     if func is None and len(kwargs) > 0:
         return _start
+    # start() is a boolean function
+    elif func is None:
+        stack = inspect.stack()
+        if len(stack) < 1:
+            return False
+        frame = stack[1][0]
+        if not inspect.isframe(frame):
+            return False
+        return frame.f_globals['__name__'] == '__main__'
     # not correctly used to decorate a function
     elif not callable(func):
         raise ValueError("Function '{0!r}' is not callable".format(func))

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -115,8 +115,8 @@ def test_positional_with_annotation(self):
     parser = cmdline.create_parser(main)
     self.assertEqual(len(parser._optionals._actions), 4)
     self.assertEqual(parser._optionals._actions[1].help, 'help string')
-    self.assertEqual(parser._optionals._actions[2].help, '')
-    self.assertTrue(parser._optionals._actions[3].help.startswith('flagged'))
+    self.assertTrue(parser._optionals._actions[2].help.startswith('flagged'))
+    self.assertEqual(parser._optionals._actions[3].help, '')
 
 def test_positional_with_annotation_and_default(self):
     def main(opt:'help string'='default'):


### PR DESCRIPTION
Adds the option to specify "double_flags=False" to avoid generating flags for the default option. (EG, if default is 'foo=True', it will only generate '--no-foo' option and not the redundant '--foo' option.)

double_flags defaults to True (ie, the same behaviour as before).

This patch also changes the order flag arguments are generated in; the non-default is always generated first (ie '--foo' if default false, '--no-foo' if default true). A test case has been updated to reflect this change.