### PR TITLE
Fix 'config_section' and add ability to parse multiple sections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,6 @@ docs/_build/
 
 # PyBuilder
 target/
+
+# PyCharm
+.idea

--- a/begin/cmdline.py
+++ b/begin/cmdline.py
@@ -58,12 +58,12 @@ class DefaultsManager(object):
     def from_name(self, name, default=NODEFAULT, section=None):
         "Get default value from argument name"
         sections = self._get_list_section(section) if section is not None else self.section
-        if len(sections) > 0:
-            for sec in self.section:
-                try:
-                    default = self._parser.get(sec, name)
-                except (configparser.NoSectionError, configparser.NoOptionError):
-                    pass
+        for sec in sections:
+            try:
+                default = self._parser.get(sec, name)
+                break
+            except (configparser.NoSectionError, configparser.NoOptionError):
+                pass
         if self._use_env:
             default = os.environ.get(self.metavar(name), default)
         return default

--- a/begin/cmdline.py
+++ b/begin/cmdline.py
@@ -163,7 +163,8 @@ def create_parser(func, env_prefix=None, config_file=None, config_section=None,
     arguments will raise a ValueError exception. A prefix on expected
     environment variables can be added using the env_prefix argument.
     """
-    defaults = DefaultsManager(env_prefix, config_file, func.__name__)
+    section = config_section if config_section is not None else func.__name__
+    defaults = DefaultsManager(env_prefix, config_file, section)
     parser = argparse.ArgumentParser(
             prog=program_name(sys.argv[0], func),
             argument_default=NODEFAULT,
@@ -194,7 +195,8 @@ def create_parser(func, env_prefix=None, config_file=None, config_section=None,
             subparser = subparsers.add_parser(subfunc.__name__, help=help,
                     conflict_handler='resolve', description=subfunc.__doc__,
                     formatter_class=formatter_class)
-            defaults.set_config_section(subfunc.__name__)
+            section = config_section if config_section is not None else subfunc.__name__
+            defaults.set_config_section(section)
             populate_parser(subparser, defaults, funcsig, short_args, lexical_order)
     return parser
 

--- a/begin/cmdline.py
+++ b/begin/cmdline.py
@@ -87,9 +87,10 @@ class DefaultsManager(object):
             return list()
         else:
             raise TypeError(
-                "'config_section' should be of {} or {}. You passed {}.".format(type(list()),
-                                                                                type(str()),
-                                                                                type(section)))
+                "'config_section' should be of {0} or {1}. You passed {2}.".format(
+                    type(list()),
+                    type(str()),
+                    type(section)))
         return _section
 
     def set_config_section(self, section):

--- a/tests/config_test.cfg
+++ b/tests/config_test.cfg
@@ -7,3 +7,4 @@ foo_arg = foo_value
 
 [bar]
 bar_arg = bar_value
+arg = bar_alt_value

--- a/tests/config_test.cfg
+++ b/tests/config_test.cfg
@@ -1,2 +1,9 @@
 [main]
 arg = value
+
+[foo]
+arg = alt_value
+foo_arg = foo_value
+
+[bar]
+bar_arg = bar_value

--- a/tests/test_begins.py
+++ b/tests/test_begins.py
@@ -29,4 +29,4 @@ class TestBegins(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    unittest.begin()
+    unittest.main()

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -191,6 +191,7 @@ def test_variable_positional_with_annotation(self):
         expanduser.return_value = os.path.join(os.curdir, 'tests')
         parser = cmdline.create_parser(main, config_file='config_test.cfg', config_section=['foo', 'bar'])
         self.assertEqual(parser._optionals._actions[1].default, 'alt_value')
+        self.assertNotEqual(parser._optionals._actions[1].default, 'bar_alt_value')
         self.assertEqual(parser._optionals._actions[2].default, cmdline.NODEFAULT)
         self.assertEqual(parser._optionals._actions[3].default, 'foo_value')
         self.assertEqual(parser._optionals._actions[4].default, 'bar_value')

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -174,6 +174,45 @@ def test_variable_positional_with_annotation(self):
         self.assertEqual(parser._optionals._actions[1].default, 'value')
         self.assertEqual(parser._optionals._actions[2].default, cmdline.NODEFAULT)
 
+    @mock.patch('os.path.expanduser')
+    def test_configfile_config_section(self, expanduser):
+        def main(arg, unk, foo_arg):
+            pass
+        expanduser.return_value = os.path.join(os.curdir, 'tests')
+        parser = cmdline.create_parser(main, config_file='config_test.cfg', config_section='foo')
+        self.assertEqual(parser._optionals._actions[1].default, 'alt_value')
+        self.assertEqual(parser._optionals._actions[2].default, cmdline.NODEFAULT)
+        self.assertEqual(parser._optionals._actions[3].default, 'foo_value')
+
+    @mock.patch('os.path.expanduser')
+    def test_configfile_multiple_config_section(self, expanduser):
+        def main(arg, unk, foo_arg, bar_arg):
+            pass
+        expanduser.return_value = os.path.join(os.curdir, 'tests')
+        parser = cmdline.create_parser(main, config_file='config_test.cfg', config_section=['foo', 'bar'])
+        self.assertEqual(parser._optionals._actions[1].default, 'alt_value')
+        self.assertEqual(parser._optionals._actions[2].default, cmdline.NODEFAULT)
+        self.assertEqual(parser._optionals._actions[3].default, 'foo_value')
+        self.assertEqual(parser._optionals._actions[4].default, 'bar_value')
+
+    @mock.patch('os.path.expanduser')
+    def test_configfile_wrong_config_section(self, expanduser):
+        def main(arg, unk, foo_arg, bar_arg):
+            pass
+        expanduser.return_value = os.path.join(os.curdir, 'tests')
+        with self.assertRaises(TypeError):
+            cmdline.create_parser(main, config_file='config_test.cfg', config_section=('foo', 'bar'))
+        with self.assertRaises(TypeError):
+            cmdline.create_parser(main, config_file='config_test.cfg', config_section={'foo', 'bar'})
+
+    @mock.patch('os.path.expanduser')
+    def test_configfile_missing_config_file(self, expanduser):
+        def main(arg, unk):
+            pass
+        expanduser.return_value = os.path.join(os.curdir, 'tests')
+        with self.assertWarns(UserWarning):
+            cmdline.create_parser(main, config_section='foo')
+
     def test_help_strings(self):
         def main(a, b=None):
             pass
@@ -374,4 +413,4 @@ def test_keyword_only(self):
 
 
 if __name__ == "__main__":
-    unittest.begin()
+    unittest.main()

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -204,7 +204,7 @@ def test_variable_positional_with_annotation(self):
         with self.assertRaises(TypeError):
             cmdline.create_parser(main, config_file='config_test.cfg', config_section=('foo', 'bar'))
         with self.assertRaises(TypeError):
-            cmdline.create_parser(main, config_file='config_test.cfg', config_section={'foo', 'bar'})
+            cmdline.create_parser(main, config_file='config_test.cfg', config_section=set(['foo', 'bar']))
 
     @mock.patch('os.path.expanduser')
     def test_configfile_missing_config_file(self, expanduser):
@@ -345,7 +345,7 @@ class TestApplyOptions(unittest.TestCase):
 
     def test_variable_keywords(self):
         def main(**kwargs):
-            return dict(args)
+            return dict(kwargs)
         with self.assertRaises(cmdline.CommandLineError):
             value = cmdline.apply_options(main, self.opts)
 

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -181,4 +181,4 @@ class TestLoging(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    unittest.begin()
+    unittest.main()

--- a/tests/test_start.py
+++ b/tests/test_start.py
@@ -81,7 +81,7 @@ class TestStart(unittest.TestCase):
     def test_command_line(self):
         target = mock.Mock()
         try:
-            orig_argv= sys.argv
+            orig_argv = sys.argv
             sys.argv = orig_argv[:1] + ['A']
             orig_name = globals()['__name__']
             globals()['__name__'] = "__main__"
@@ -401,4 +401,4 @@ class TestStart(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    unittest.begin()
+    unittest.main()


### PR DESCRIPTION
- Fix passing `config_section` with arbitrary name not working anymore.
- Read parameters from multiple-sections config-file with `config_section` as a list of sections names.

eg.
```python
@begin.start(config_file='conf.ini', config_section=['foo', 'bar'])
def main(value1=None, value2=None):
    print('value1: {}, value2:{}'.format(value1, value2))
```

with `conf.ini` as

```ini
[foo]
value1 = asd

[bar]
value2 = 123
```